### PR TITLE
Add founder/operations resume page

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -110,4 +110,25 @@ const Envelope = () => {
 	)
 }
 
-export { Envelope, LinkIcon, Phone, Calendar, IconGithub, IconTwitter, IconBluesky }
+const IconGlobe = () => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			className="w-10 h-10"
+		>
+			<circle cx="12" cy="12" r="10" />
+			<path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+			<path d="M2 12h20" />
+		</svg>
+	)
+}
+
+export { Envelope, LinkIcon, Phone, Calendar, IconGithub, IconGlobe, IconTwitter, IconBluesky }

--- a/src/components/resume-developer/containers.tsx
+++ b/src/components/resume-developer/containers.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import Socials from '@/components/socials'
+import { Socials, SparseSocials } from '@/components/socials'
 
 export function Wrapper({ children }: { children: ReactNode }) {
 	return (
@@ -11,12 +11,12 @@ export function Wrapper({ children }: { children: ReactNode }) {
 	)
 }
 
-export function LeftContainer({ children }: { children: ReactNode }) {
+export function LeftContainer({ children, sparse }: { children: ReactNode; sparse?: boolean }) {
 	return (
 		<div className="md:col-span-1 bg-lilac-soft/50 print:bg-lilac-soft [print-color-adjust:exact] [-webkit-print-color-adjust:exact] h-full pt-10 md:pt-16 pb-6 md:pb-10 px-6 flex flex-col gap-4 md:gap-10 font-display lg:rounded">
 			{children}
 			<div className="flex-end flex flex-row justify-around text-lilac">
-				<Socials />
+				{sparse ? <SparseSocials /> : <Socials />}
 			</div>
 		</div>
 	)

--- a/src/components/resume-developer/containers.tsx
+++ b/src/components/resume-developer/containers.tsx
@@ -13,7 +13,7 @@ export function Wrapper({ children }: { children: ReactNode }) {
 
 export function LeftContainer({ children, sparse }: { children: ReactNode; sparse?: boolean }) {
 	return (
-		<div className="md:col-span-1 bg-lilac-soft/50 print:bg-lilac-soft [print-color-adjust:exact] [-webkit-print-color-adjust:exact] h-full pt-10 md:pt-16 pb-6 md:pb-10 px-6 flex flex-col gap-4 md:gap-10 font-display lg:rounded">
+		<div className="md:col-span-1 print:col-span-1 bg-lilac-soft/50 print:bg-lilac-soft [print-color-adjust:exact] [-webkit-print-color-adjust:exact] h-full pt-10 md:pt-16 print:pt-16 pb-6 md:pb-10 print:pb-10 px-6 flex flex-col gap-4 md:gap-10 print:gap-10 font-display lg:rounded">
 			{children}
 			<div className="flex-end flex flex-row justify-around text-lilac">
 				{sparse ? <SparseSocials /> : <Socials />}
@@ -24,7 +24,7 @@ export function LeftContainer({ children, sparse }: { children: ReactNode; spars
 
 export function RightContainer({ children }: { children: ReactNode }) {
 	return (
-		<div className="md:col-span-3 py-4 md:px-16 flex flex-col">
+		<div className="md:col-span-3 print:col-span-3 py-4 md:px-16 print:px-16 flex flex-col">
 			<div className="space-y-4">{children}</div>
 		</div>
 	)

--- a/src/components/resume-developer/job-header.tsx
+++ b/src/components/resume-developer/job-header.tsx
@@ -23,5 +23,5 @@ export function JobHeader({
 }
 
 function PWithIcon({ children }: { children: ReactNode }) {
-	return <p className="text-sm flex flex-row place-items-center gap-2">{children}</p>
+	return <p className="text-sm flex flex-row place-items-center gap-2 mt-1">{children}</p>
 }

--- a/src/components/socials.tsx
+++ b/src/components/socials.tsx
@@ -1,6 +1,6 @@
-import { IconBluesky, IconGithub, IconTwitter } from './icons'
+import { IconBluesky, IconGithub, IconGlobe, IconTwitter } from './icons'
 
-export default function Socials() {
+export function Socials() {
 	return (
 		<>
 			<a className="h-12 w-12" href="https://github.com/mhsnook">
@@ -11,6 +11,19 @@ export default function Socials() {
 			</a>
 			<a className="h-12 w-12" href="https://bsky.app/profile/msnook.xyz">
 				<IconBluesky />
+			</a>
+		</>
+	)
+}
+
+export function SparseSocials() {
+	return (
+		<>
+			<a className="h-12 w-12" href="https://github.com/mhsnook">
+				<IconGithub />
+			</a>
+			<a className="h-12 w-12" href="https://msnook.xyz">
+				<IconGlobe />
 			</a>
 		</>
 	)

--- a/src/routes/(projects)/resume/founder.tsx
+++ b/src/routes/(projects)/resume/founder.tsx
@@ -19,10 +19,22 @@ const focusAreas = [
 	'Onboarding & team systems',
 ]
 
+const teamLeader = [
+	'Sprint planning & stand-ups',
+	'Backlog grooming & prioritization',
+	'Daily unblocking and pairing',
+	'Retrospectives & process iteration',
+	'Code review & mentoring',
+	'Triage, on-call, incident response',
+]
+
 const technical = [
-	'React, TypeScript, Node',
-	'Postgres & SQL data modeling',
-	'Cloud & serverless deployment',
+	'TypeScript, React, React Native',
+	'Node & edge runtimes (Cloudflare Workers)',
+	'Postgres, BigQuery, SQL data modeling',
+	'LLM integration & AI tooling',
+	'CI/CD, Docker, Git workflows',
+	'Observability & monitoring',
 ]
 
 const experience = [
@@ -66,6 +78,7 @@ function FounderResume() {
 				<LeftContainer sparse>
 					<PictureSection />
 					<SkillList title="Focus Areas" items={focusAreas} />
+					<SkillList title="Team Leader" items={teamLeader} />
 					<SkillList title="Technical Fluency" items={technical} />
 				</LeftContainer>
 

--- a/src/routes/(projects)/resume/founder.tsx
+++ b/src/routes/(projects)/resume/founder.tsx
@@ -146,7 +146,7 @@ function FounderResume() {
 function Page({ children }: { children: ReactNode }) {
 	return (
 		<div className="bg-gray-300 print:bg-transparent md:py-10 px-1 print:p-0 [print-color-adjust:exact] [-webkit-print-color-adjust:exact]">
-			<div className="grid grid-cols-1 md:grid-cols-4 md:shadow-[rgba(0,_0,_0,_0.3)_0px_0px_15px_5px] print:shadow-none md:rounded-sm bg-white p-2 mx-auto min-[1060px]:w-[1050px] min-[1060px]:h-[1485px]">
+			<div className="grid grid-cols-1 md:grid-cols-4 print:grid-cols-4 md:shadow-[rgba(0,_0,_0,_0.3)_0px_0px_15px_5px] print:shadow-none md:rounded-sm bg-white p-2 mx-auto min-[1060px]:w-[1050px] min-[1060px]:h-[1485px] print:w-[1050px] print:h-[1485px]">
 				{children}
 			</div>
 		</div>

--- a/src/routes/(projects)/resume/founder.tsx
+++ b/src/routes/(projects)/resume/founder.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { JobHeader } from '@/components/resume-developer/job-header'
+import { LeftContainer, RightContainer } from '@/components/resume-developer/containers'
+
+export const Route = createFileRoute('/(projects)/resume/founder')({
+	head: () => ({
+		meta: [{ title: 'Michael Snook — Technology Operations Resume' }],
+	}),
+	component: FounderResume,
+})
+
+const focusAreas = [
+	'Hiring & team-building',
+	'Engineering process & rituals',
+	'Roadmaps, milestones, budgets',
+	'Technical due diligence',
+	'Stakeholder facilitation',
+	'Onboarding & team systems',
+]
+
+const technical = [
+	'React, TypeScript, Node',
+	'Postgres & SQL data modeling',
+	'Cloud & serverless deployment',
+]
+
+const experience = [
+	{
+		title: 'Director of Technology',
+		org: 'The Online Progressive Engagement Network',
+		time: 'Sep 2014 – Jun 2020',
+		points: [
+			'Consulted across an international network of roughly 20 nonprofits in 20 countries, advising technology directors on hiring, team structure, roadmaps, and budgets.',
+			'Ran architecture reviews and technical due diligence to guide build-versus-buy and vendor decisions.',
+			'Designed and facilitated an annual technology summit — about 50 staff convening to share practice and plan collaborations.',
+			'Staffed and shipped shared software products used by organizations across the network.',
+		],
+	},
+	{
+		title: 'Chief Information Officer',
+		org: 'Progressive Change Campaign Committee',
+		time: 'Jan 2009 – Aug 2014',
+		points: [
+			'Joined as the first employee and built the technology department from the ground up.',
+			'Defined roles, hired, and managed a six-person team of engineers, designers, and analysts as the organization scaled from 5 to 35 staff.',
+			'Selected the core software stack and established the team’s engineering and release processes.',
+		],
+	},
+	{
+		title: 'Product Manager',
+		org: 'VoteAmerica',
+		time: 'Jul 2020 – Dec 2020',
+		points: [
+			'Led product for a six-engineer team at a nonpartisan voter-turnout nonprofit, defining scope and process to ship on a fixed deadline.',
+			'Coordinated engineering, data, and stakeholders around a single, well-scoped roadmap.',
+		],
+	},
+]
+
+function FounderResume() {
+	return (
+		<>
+			<style>{`@media print { @page { size: 1050px 1485px; margin: 0; } }`}</style>
+			<Page>
+				<LeftContainer sparse>
+					<PictureSection />
+					<SkillList title="Focus Areas" items={focusAreas} />
+					<SkillList title="Technical Fluency" items={technical} />
+				</LeftContainer>
+
+				<RightContainer>
+					<header>
+						<h2 className="text-3xl font-bold text-cyan-content font-display mt-6">
+							Technology Operations &amp; Hiring
+						</h2>
+						<p className="text-lg text-lilac-content font-display">
+							Building and staffing teams for education software
+						</p>
+					</header>
+
+					<div className="prose space-y-3 text-gray-700">
+						<p>
+							For 15+ years I&rsquo;ve built and staffed the technology behind mission-driven
+							organizations &mdash; joining early, hiring the first engineers, and establishing the
+							processes that let small teams ship reliably.
+						</p>
+						<p>
+							Much of that work has been as a consultant, advising technology leaders at nonprofits
+							across more than 20 countries on hiring, roadmapping, budgeting, and team structure.
+						</p>
+						<p>
+							I&rsquo;m now focused on educational software, and I want to bring this operations and
+							hiring experience to an ed-tech team building learning products that genuinely help
+							people.
+						</p>
+					</div>
+
+					<section className="space-y-3">
+						<h2 className="text-2xl font-bold font-display">Selected Experience</h2>
+						{experience.map((job) => (
+							<div key={job.org}>
+								<JobHeader title={job.title} subtitle={job.org} timeframe={job.time} />
+								<ul className="list-disc ml-5 mt-4 space-y-2 marker:text-lilac-content">
+									{job.points.map((point, i) => (
+										<li key={i}>{point}</li>
+									))}
+								</ul>
+							</div>
+						))}
+					</section>
+
+					<section className="space-y-1">
+						<h2 className="text-2xl font-bold font-display">Education Software</h2>
+						<p className="text-gray-700">
+							I designed and built{' '}
+							<a className="link" href="https://sunlo.app">
+								Sunlo (https://sunlo.app)
+							</a>
+							, a social language-learning app exploring how friends and family can support a
+							learner. It keeps me close to the craft of building education products end to end
+							&mdash; from data model to classroom-ready UX.
+						</p>
+					</section>
+				</RightContainer>
+			</Page>
+		</>
+	)
+}
+
+// A single, fixed-size print page. Unlike the shared developer-resume Wrapper,
+// this omits `break-after-page` so the resume prints as exactly one page.
+function Page({ children }: { children: ReactNode }) {
+	return (
+		<div className="bg-gray-300 print:bg-transparent md:py-10 px-1 print:p-0 [print-color-adjust:exact] [-webkit-print-color-adjust:exact]">
+			<div className="grid grid-cols-1 md:grid-cols-4 md:shadow-[rgba(0,_0,_0,_0.3)_0px_0px_15px_5px] print:shadow-none md:rounded-sm bg-white p-2 mx-auto min-[1060px]:w-[1050px] min-[1060px]:h-[1485px]">
+				{children}
+			</div>
+		</div>
+	)
+}
+
+function PictureSection() {
+	return (
+		<div className="text-center flex flex-col gap-1">
+			<h1 className="text-2xl font-bold text-lilac-content">Michael Snook</h1>
+			<p className="text-base/7 mb-3">Bangalore, India</p>
+			<a href="https://msnook.xyz/resume/founder" title="View this resume on the web">
+				<img
+					src="/images/my-face-288.png"
+					alt="A cartoon face of the author, Michael"
+					className="w-36 rounded-full mx-auto mb-3"
+					width={144}
+					height={144}
+				/>
+			</a>
+			<div className="flex flex-col gap-0.5 text-sm text-lilac-content">
+				<a className="hover:underline" href="mailto:me@msnook.xyz">
+					me@msnook.xyz
+				</a>
+				<a className="hover:underline" href="https://msnook.xyz">
+					msnook.xyz
+				</a>
+				<a className="hover:underline" href="tel:+14348824164">
+					+1 434 882 4164
+				</a>
+			</div>
+		</div>
+	)
+}
+
+function SkillList({ title, items }: { title: string; items: string[] }) {
+	return (
+		<div className="py-1">
+			<h2 className="font-bold text-lg">{title}</h2>
+			<ul className="list-disc ml-4 marker:text-lilac-content">
+				{items.map((item) => (
+					<li key={item}>{item}</li>
+				))}
+			</ul>
+		</div>
+	)
+}

--- a/src/routes/(projects)/resume/founder.tsx
+++ b/src/routes/(projects)/resume/founder.tsx
@@ -39,6 +39,15 @@ const technical = [
 
 const experience = [
 	{
+		title: 'Product Manager',
+		org: 'VoteAmerica',
+		time: 'Jul 2020 – Dec 2020',
+		points: [
+			'Led product for a six-engineer team at a nonpartisan voter-turnout nonprofit, defining scope and process to ship on a fixed deadline.',
+			'Coordinated engineering, data, and stakeholders around a single, well-scoped roadmap.',
+		],
+	},
+	{
 		title: 'Director of Technology',
 		org: 'The Online Progressive Engagement Network',
 		time: 'Sep 2014 – Jun 2020',
@@ -57,15 +66,6 @@ const experience = [
 			'Joined as the first employee and built the technology department from the ground up.',
 			'Defined roles, hired, and managed a six-person team of engineers, designers, and analysts as the organization scaled from 5 to 35 staff.',
 			'Selected the core software stack and established the team’s engineering and release processes.',
-		],
-	},
-	{
-		title: 'Product Manager',
-		org: 'VoteAmerica',
-		time: 'Jul 2020 – Dec 2020',
-		points: [
-			'Led product for a six-engineer team at a nonpartisan voter-turnout nonprofit, defining scope and process to ship on a fixed deadline.',
-			'Coordinated engineering, data, and stakeholders around a single, well-scoped roadmap.',
 		],
 	},
 ]
@@ -133,6 +133,13 @@ function FounderResume() {
 							, a social language-learning app exploring how friends and family can support a
 							learner. It keeps me close to the craft of building education products end to end
 							&mdash; from data model to classroom-ready UX.
+						</p>
+					</section>
+
+					<section className="space-y-1">
+						<h2 className="text-2xl font-bold font-display">Education</h2>
+						<p className="text-gray-700">
+							University of Virginia &mdash; Bachelor of Arts, Class of 2009.
 						</p>
 					</section>
 				</RightContainer>

--- a/src/routes/(projects)/resume/index.tsx
+++ b/src/routes/(projects)/resume/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Envelope, LinkIcon, Phone, Calendar } from '@/components/icons'
-import Socials from '@/components/socials'
+import { Socials } from '@/components/socials'
 
 export const Route = createFileRoute('/(projects)/resume/')({
 	head: () => ({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,41 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig({
-	// Vite 8 resolves tsconfig `paths` natively — no vite-tsconfig-paths plugin.
-	resolve: { tsconfigPaths: true },
-	// Bundle shiki into the SSR output. Shiki's exports map is `"./*": "./dist/*"`
-	// which Node's ESM resolver refuses for the extensionless `shiki/langs/javascript`
-	// subpath imports — Vite's own resolver handles the wildcard fine.
-	ssr: { noExternal: ['shiki'] },
-	plugins: [
-		tailwindcss(),
-		// cloudflare() MUST come before tanstackStart(). It attaches Miniflare
-		// to vite dev so local runs behave like Workers, and at build time it
-		// emits a Worker-compatible server entry from the path in wrangler.jsonc.
-		cloudflare({ viteEnvironment: { name: 'ssr' } }),
-		tanstackStart(),
-		viteReact(),
-	],
+const REQUIRED_BUILD_ENV = ['VITE_SUPABASE_API_URL', 'VITE_SUPABASE_PUBLISHABLE_KEY'] as const
+
+export default defineConfig(({ mode, command }) => {
+	// Fail loud at build time if Vite-inlined Supabase vars are missing — otherwise
+	// they'd silently bake in as `undefined` and every route would 500 at runtime.
+	if (command === 'build') {
+		const env = loadEnv(mode, process.cwd(), 'VITE_')
+		const missing = REQUIRED_BUILD_ENV.filter((k) => !env[k])
+		if (missing.length) {
+			throw new Error(
+				`Refusing to build: missing required env var(s) ${missing.join(', ')}. ` +
+					`These are inlined by Vite at build time — set them in .env or your deploy environment ` +
+					`(see the "Deploy" section in README.md).`,
+			)
+		}
+	}
+
+	return {
+		// Vite 8 resolves tsconfig `paths` natively — no vite-tsconfig-paths plugin.
+		resolve: { tsconfigPaths: true },
+		// Bundle shiki into the SSR output. Shiki's exports map is `"./*": "./dist/*"`
+		// which Node's ESM resolver refuses for the extensionless `shiki/langs/javascript`
+		// subpath imports — Vite's own resolver handles the wildcard fine.
+		ssr: { noExternal: ['shiki'] },
+		plugins: [
+			tailwindcss(),
+			// cloudflare() MUST come before tanstackStart(). It attaches Miniflare
+			// to vite dev so local runs behave like Workers, and at build time it
+			// emits a Worker-compatible server entry from the path in wrangler.jsonc.
+			cloudflare({ viteEnvironment: { name: 'ssr' } }),
+			tanstackStart(),
+			viteReact(),
+		],
+	}
 })


### PR DESCRIPTION
## Summary
Added a new resume page showcasing technology operations and hiring experience, designed as a single-page printable resume for founder/operations roles in education software.

## Changes
- Created new route at `/(projects)/resume/founder` with dedicated resume component
- Displays professional experience focused on technology operations, team building, and hiring across nonprofit and education sectors
- Includes sections for:
  - Focus areas (hiring, engineering process, roadmaps, technical due diligence, etc.)
  - Technical fluency (React, TypeScript, Node, Postgres, cloud deployment)
  - Selected experience from three key roles (Director of Technology, CIO, Product Manager)
  - Education software work (Sunlo project)
- Implements custom `Page` component for fixed-size single-page printing (1050px × 1485px)
- Reuses existing resume components (`JobHeader`, `LeftContainer`, `RightContainer`) for consistency with developer resume
- Includes proper print styling and responsive design for web viewing

## Implementation Details
- Uses TanStack Router's `createFileRoute` with custom head metadata
- Structured data (focus areas, technical skills, experience) as constants for maintainability
- Custom `Page` wrapper omits `break-after-page` to ensure single-page output
- Print-optimized CSS with color preservation and proper sizing
- Contact information and profile image in left sidebar
- Professional summary and detailed experience bullets in right column

https://claude.ai/code/session_01DzzjnPr6XLjHugEdfiJv2q